### PR TITLE
use qa in subscription service instead of ci

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -61,9 +61,10 @@ const config = {
     requestTimeout: parseInt(env.REQUEST_TIMEOUT, 10) || 10000,
 
     // needs to support dev, ci, qa, prod environments
+    // We are not entitled to smart-management in subscription.dev.api, so use qa instead.
     // subscription
     subscription: {
-        dev: "https://subscription.dev.api.redhat.com",
+        dev: "https://subscription.qa.api.redhat.com",
         prod: "https://subscription.api.redhat.com",
         qa: "https://subscription.qa.api.redhat.com",
         route: "/svcrest/subscription/v5/search/criteria;web_customer_id=${orgId};sku=SVC3124;status=active",


### PR DESCRIPTION
For some reason, we're not entitled in the CI instance of the subscription service api. Let's just use QA for now until we can get it sorted out.