### PR TITLE
Use UTF8 instead of ascii to decode identity header

### DIFF
--- a/src/middleware/identity/impl.ts
+++ b/src/middleware/identity/impl.ts
@@ -15,7 +15,7 @@ export default function(req: Request, res: Response, next: any) {
     }
 
     try {
-        const value = Buffer.from(raw, "base64").toString("ascii");
+        const value = Buffer.from(raw, "base64").toString("utf8");
         req.identity = JSON.parse(value).identity;
         log.trace({identity: req.identity, reqId}, "parsed identity header");
 


### PR DESCRIPTION
### Problem description
If you have header with some non ascii characters like ěščřžýáí the parsing will be broken.

### Header example
`eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMTI3MjkiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJyaG4tZW5naW5lZXJpbmctamRvc3RhbCIsImVtYWlsIjoiamRvc3RhbCtxYUByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6IkppxZnDrSIsImxhc3RfbmFtZSI6IkRvc3TDoWwiLCJpc19hY3RpdmUiOnRydWUsImlzX29yZ19hZG1pbiI6dHJ1ZSwiaXNfaW50ZXJuYWwiOnRydWUsImxvY2FsZSI6ImVuX1VTIn0sImludGVybmFsIjp7Im9yZ19pZCI6NzY3NDI4Mn19fQ==`